### PR TITLE
Fix running ccfx from any directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,15 @@ config.log
 config.sub
 config.status
 configure
+compile
 depcomp
+install-sh
 missing
 .libs/
 Makefile
 Makefile.in
+
+picosel/picosel
+ccfx/ccfx
+*.ccfxd
+*.ccfxprep

--- a/Makefile.am
+++ b/Makefile.am
@@ -37,7 +37,10 @@ ccfx_ccfx_SOURCES = \
 	ccfx/rawclonepairdata.cpp \
 	ccfx/ccfxconstants.cpp
 
-ccfx_ccfx_CPPFLAGS = $(common_CPPFLAGS) -O2 -fpermissive
+inidir = $(sysconfdir)/ccfx
+ini_DATA = ccfx/ccfx_prep_scripts.ini
+
+ccfx_ccfx_CPPFLAGS = $(common_CPPFLAGS) -O2 -fpermissive -DINIPATH=\"$(inidir)\"
 ccfx_ccfx_LDFLAGS = $(common_LIBADD)
 
 torq_pyeasytorq_easytorq_la_CPPFLAGS = $(common_CPPFLAGS) \
@@ -56,7 +59,8 @@ torq_pyeasytorq_easytorq_la_LIBADD = $(common_LIBADD)
 torq_pyeasytorq_easytorq_la_LDFLAGS = -avoid-version -module
 
 ccfx_CCFinderXLib_lib_CCFinderXLib_la_CPPFLAGS = $(common_CPPFLAGS) \
-	-O2 -fpermissive -I/usr/lib/jvm/java-6-openjdk/include/
+	-O2 -fpermissive -I/usr/lib/jvm/java-6-openjdk/include/ \
+	-DINIPATH="\"$(inidir)\""
 
 ccfx_CCFinderXLib_lib_CCFinderXLib_la_SOURCES = \
 	GemX/ccfinderx_CCFinderX.h \

--- a/ccfx/ccfxcommon.cpp
+++ b/ccfx/ccfxcommon.cpp
@@ -691,7 +691,7 @@ int read_script_table(std::vector<std::pair<std::string/* ext */, std::string/* 
 	std::vector<std::pair<std::string/* ext */, std::string/* scriptFile */> > &data = *pOutput;
 
 	std::vector<std::string> descFiles;
-	descFiles.push_back(make_filename_on_the_same_directory("ccfx_prep_scripts.ini", argv0));
+	descFiles.push_back(INIPATH "/ccfx_prep_scripts.ini");
 
 	if (oOptionalPrepScriptDescriptionFiles) {
 		const std::vector<std::string> &dfs = *oOptionalPrepScriptDescriptionFiles;


### PR DESCRIPTION
ccfx opens ccfx_prep_scripts.ini from the current directory at present. It won't work if ccfx is installed system-wide, since the ini file should be cannot be copied everywhere you want to run it. This patch installs this ini file into $(sysconfdir)/ccfx and ccfxcommon.cpp needs the INIPATH symbol which is now passed externally on the compiler command line. RPM or DEB packagers automatically pass --sysconfig=/etc to ./configure among other parameters so the ini file end up in /etc/ccfx.
